### PR TITLE
feat: Connect plan selection to registration and checkout

### DIFF
--- a/backend/handlers/auth.js
+++ b/backend/handlers/auth.js
@@ -24,9 +24,12 @@ const register = async (req, res) => {
       RETURNING id;
     `;
     const values = [email, companyName, passwordHash];
-    await db.query(insertQuery, values);
+    const { rows } = await db.query(insertQuery, values);
+    const newUser = rows[0];
 
-    return res.status(201).json({ message: 'User registered successfully.' });
+    const token = jwt.sign({ landlordId: newUser.id }, process.env.JWT_SECRET, { expiresIn: process.env.JWT_EXPIRATION_TIME || '8h' });
+
+    return res.status(201).json({ token });
   } catch (error) {
     console.error('Database error:', error);
     return res.status(500).json({ error: 'Internal Server Error' });

--- a/frontend/src/components/Pricing.js
+++ b/frontend/src/components/Pricing.js
@@ -10,7 +10,7 @@ const Pricing = () => {
 
     const handleChoosePlan = async (priceId) => {
         if (!token) {
-            navigate('/register');
+            navigate(`/register?plan=${priceId}`);
             return;
         }
 


### PR DESCRIPTION
This commit refactors the new user registration flow to seamlessly connect plan selection with the checkout process.

Frontend:
- The pricing page now passes the selected plan's Stripe Price ID as a URL query parameter to the registration page.
- The registration page captures the plan ID and, after successful registration, automatically logs the user in.
- If a plan was selected, the user is redirected to the Stripe checkout for that plan.
- If no plan was selected, the user is redirected to the main dashboard.

Backend:
- The POST /register endpoint has been improved to generate and return a JWT immediately upon creating a new user. This streamlines the frontend flow by eliminating the need for a separate login API call after registration.