### PR TITLE
feat: Implement Secure Tink Callback Flow

### DIFF
--- a/backend/handlers/handleTinkCallback.js
+++ b/backend/handlers/handleTinkCallback.js
@@ -49,13 +49,13 @@ const handleTinkCallback = async (req, res) => {
     // Immediately update the applicant's status to 'in_progress'
     await db.query("UPDATE applicants SET status = 'in_progress' WHERE id = $1", [applicantId]);
 
-    // Step 5: Redirect the user to a success page.
-    const successUrl = `${process.env.FRONTEND_URL}/check/success`;
-    return res.redirect(successUrl);
+    // Step 5: Respond to the frontend.
+    return res.status(200).json({ success: true, message: 'Tink flow completed successfully.' });
 
   } catch (error) {
     console.error('Error in Tink callback handler:', error.response ? error.response.data : error.message);
-    return res.status(500).json({ error: 'An error occurred during the Tink flow.' });
+    const successUrl = `${process.env.FRONTEND_URL}/check/error`;
+    return res.status(500).json({ success: false, error: 'An error occurred during the Tink flow.' });
   }
 };
 

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -4,6 +4,7 @@ import { loadStripe } from '@stripe/stripe-js';
 import { Elements } from '@stripe/react-stripe-js';
 import Dashboard from './components/Dashboard';
 import ApplicantPortal from './components/ApplicantPortal';
+import TinkCallback from './components/TinkCallback';
 import SuccessPage from './components/SuccessPage';
 import ReportView from './components/ReportView';
 import Login from './components/Login';
@@ -27,6 +28,7 @@ function App() {
             <Route path="/" element={<LandingPage />} />
             <Route path="/login" element={<Login />} />
           <Route path="/register" element={<Register />} />
+            <Route path="/callback/tink" element={<TinkCallback />} />
           <Route path="/check/success" element={<SuccessPage />} />
           <Route path="/check/:token" element={<ApplicantPortal />} />
 

--- a/frontend/src/components/ApplicantPortal.js
+++ b/frontend/src/components/ApplicantPortal.js
@@ -49,9 +49,10 @@ const ApplicantPortal = () => {
       </div>
       <div className="portal-footer">
         <button className="start-check-button" onClick={() => {
+          const redirect_uri = `${window.location.origin}/callback/tink`;
           const tinkLink = 'https://link.tink.com/1.0/authorize/' +
             '?client_id=' + process.env.REACT_APP_TINK_CLIENT_ID +
-            '&redirect_uri=' + encodeURIComponent('http://localhost:3000/callback/tink') +
+            '&redirect_uri=' + encodeURIComponent(redirect_uri) +
             '&scope=accounts:read,transactions:read' +
             '&market=GB' +
             '&state=' + token;

--- a/frontend/src/components/TinkCallback.js
+++ b/frontend/src/components/TinkCallback.js
@@ -1,0 +1,46 @@
+import React, { useState, useEffect } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import api from '../services/api';
+
+const TinkCallback = () => {
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const processTinkCallback = async () => {
+      const queryParams = new URLSearchParams(location.search);
+      const code = queryParams.get('code');
+      const state = queryParams.get('state');
+
+      if (!code || !state) {
+        setError('Invalid callback parameters.');
+        setLoading(false);
+        return;
+      }
+
+      try {
+        await api.get(`/callback/tink?code=${code}&state=${state}`);
+        navigate('/check/success');
+      } catch (err) {
+        setError('Failed to complete the secure check. Please try again.');
+        setLoading(false);
+      }
+    };
+
+    processTinkCallback();
+  }, [location, navigate]);
+
+  if (loading) {
+    return <div className="portal-container"><p>Processing your secure check...</p></div>;
+  }
+
+  if (error) {
+    return <div className="portal-container"><p className="error-message">{error}</p></div>;
+  }
+
+  return null;
+};
+
+export default TinkCallback;


### PR DESCRIPTION
This commit refactors the Tink integration to use a secure, frontend-based redirect flow.

The changes include:
- A new `TinkCallback` component on the frontend to handle the redirect from Tink.
- A new `/callback/tink` route on the frontend.
- The `ApplicantPortal` now dynamically constructs the `redirect_uri`.
- The backend `handleTinkCallback` handler now returns a JSON response instead of a redirect.

This new flow prevents CORS issues and keeps sensitive communication between the backend and Tink server-to-server.