### PR TITLE
Fix(stripe): Resolve webhook signature verification error

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -3,8 +3,6 @@ const serverless = require('serverless-http');
 const rateLimit = require('express-rate-limit');
 const app = express();
 
-app.use(express.json());
-
 // Rate Limiting
 const generalLimiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
@@ -38,14 +36,14 @@ const { validateCheck } = require('./handlers/validateCheck');
 // Routes
 app.post('/stripe-webhook', express.raw({type: 'application/json'}), stripeWebhook);
 
-app.post('/register', authLimiter, validate(registerSchema), register);
-app.post('/login', authLimiter, validate(loginSchema), login);
-app.post('/checks', authorize, validate(createCheckSchema), createCheck);
+app.post('/register', express.json(), authLimiter, validate(registerSchema), register);
+app.post('/login', express.json(), authLimiter, validate(loginSchema), login);
+app.post('/checks', express.json(), authorize, validate(createCheckSchema), createCheck);
 app.get('/checks/:token', validate(require('./middleware/validation').validateCheckSchema, 'params'), validateCheck);
 app.get('/applicants', authorize, getApplicants);
 app.get('/reports/:applicantId', authorize, validate(require('./middleware/validation').getReportSchema, 'params'), getReport);
 app.get('/callback/tink', validate(require('./middleware/validation').handleTinkCallbackSchema, 'query'), handleTinkCallback);
-app.post('/create-checkout-session', authorize, validate(require('./middleware/validation').createCheckoutSessionSchema), createCheckoutSession);
+app.post('/create-checkout-session', express.json(), authorize, validate(require('./middleware/validation').createCheckoutSessionSchema), createCheckoutSession);
 app.get('/subscription', authorize, getSubscription);
 app.post('/create-portal-session', authorize, createPortalSession);
 app.get('/account/status', authorize, getAccountStatus);


### PR DESCRIPTION
The Stripe webhook handler was failing because the serverless framework was parsing the JSON request body before it reached the Stripe SDK, which requires the raw request body for signature verification.

This commit fixes the issue by modifying the Express middleware configuration in `backend/app.js`.

- The global `express.json()` middleware is removed.
- `express.json()` is applied individually to routes that require JSON body parsing.
- The `/stripe-webhook` route continues to use `express.raw({type: 'application/json'})`, ensuring it receives the unparsed request body.

This change allows the Stripe SDK to correctly verify the webhook signature while preserving the expected behavior for all other API endpoints.